### PR TITLE
added option to hide report links

### DIFF
--- a/content_scripts/live_show_qol.js
+++ b/content_scripts/live_show_qol.js
@@ -1,11 +1,12 @@
 var show_emotes_menu = false;
 var show_infobuttons = false;
+var hide_report = false;
 
 // handle options, using browser-specific option retrieval.
 if (navigator.userAgent.indexOf("Chrome") != -1) {
-  chrome.storage.sync.get(["chat_emotes", "infinite_infobuttons"], handleOptions);
+  chrome.storage.sync.get(["chat_emotes", "infinite_infobuttons", "hide_report"], handleOptions);
 } else {
-  getting = browser.storage.sync.get(["chat_emotes", "infinite_infobuttons"]);
+  getting = browser.storage.sync.get(["chat_emotes", "infinite_infobuttons", "hide_report"]);
   getting.then(handleOptions, onError);
 }
 
@@ -17,6 +18,10 @@ function handleOptions(item) {
 
   if (item.infinite_infobuttons === undefined || item.infinite_infobuttons) {
     show_infobuttons = true;
+  }
+
+  if (item.hide_report) {
+    hide_report = true;
   }
 }
 
@@ -37,6 +42,10 @@ function setupLiveShowFeatures() {
 
     if (show_infobuttons && window.location.href.indexOf("infinite") > -1) {
       infobuttonSetup();
+    }
+
+    if (hide_report) {
+      hideReportButtons();
     }
   }
 }
@@ -263,4 +272,12 @@ function buildQueryString(text) {
   search_text = search_text.replace(/\s+/g, " ");
   // return URI-encoded string
   return encodeURI(search_text);
+}
+
+function hideReportButtons() {
+  // create new style element and set all report links to display: none
+  const style = document.createElement('style');
+  style.innerHTML = `.chat-history__report { display: none; }`;
+
+  document.head.appendChild(style);
 }

--- a/options/options.html
+++ b/options/options.html
@@ -70,7 +70,13 @@
         <input type="checkbox" id="cbox_infinite_infobuttons" checked="true"/><br>
       </span>
     </div>
-
+    <hr>
+    <div>
+      <span class="option-text"><label>Hide "Report" links in chat</label></span>
+      <span class="centered">
+        <input type="checkbox" id="cbox_hide_report" checked="false"/><br>
+      </span>
+    </div>
     <script src="../third_party/jquery-3.5.1.min.js"></script>
     <script src="options.js"></script>
 

--- a/options/options.js
+++ b/options/options.js
@@ -9,7 +9,8 @@ var apiKey              = document.querySelector("#text_api_key"),
     streamNotifications = document.querySelector("#cbox_stream_notifications"),
     hideTitrSpoilers    = document.querySelector("#cbox_hide_titr_spoilers"),
     chatEmotes          = document.querySelector("#cbox_chat_emotes"),
-    infiniteInfobuttons = document.querySelector("#cbox_infinite_infobuttons");
+    infiniteInfobuttons = document.querySelector("#cbox_infinite_infobuttons"),
+    hideReport          = document.querySelector("#cbox_hide_report");
 
 // Invoke saveOptions whenever an option is changed
 $(apiKey).on("input", saveOptions);
@@ -17,6 +18,7 @@ $(streamNotifications).on("change", saveOptions);
 $(hideTitrSpoilers).on("change", saveOptions);
 $(chatEmotes).on("change", saveOptions);
 $(infiniteInfobuttons).on("change", saveOptions);
+$(hideReport).on("change", saveOptions);
 
 // Handle mouseover of all infobuttons
 $(".option-infobutton-container").on("mouseover", function() {
@@ -43,7 +45,8 @@ function saveOptions(e) {
     stream_notifications: streamNotifications.checked,
     hide_titr_spoilers: hideTitrSpoilers.checked,
     chat_emotes: chatEmotes.checked,
-    infinite_infobuttons: infiniteInfobuttons.checked
+    infinite_infobuttons: infiniteInfobuttons.checked,
+    hide_report: hideReport.checked
   };
 
   browser.storage.sync.set(options);
@@ -115,6 +118,14 @@ function restoreOptions() {
     }
   }
 
+  function setHideReport(result) {
+    if (result.hide_report !== undefined) {
+      hideReport.checked = result.hide_report;
+    } else {
+      hideReport.checked = false;
+    }
+  }
+
   // Firefox and Chrome handle storage get and set differently
   if (navigator.userAgent.indexOf("Chrome") != -1) {
     chrome.storage.sync.get("api_key", setApiKey);
@@ -122,12 +133,14 @@ function restoreOptions() {
     chrome.storage.sync.get("hide_titr_spoilers", setHideTitrSpoilers);
     chrome.storage.sync.get("chat_emotes", setChatEmotes);
     chrome.storage.sync.get("infinite_infobuttons", setInfiniteInfobuttons);
+    chrome.storage.sync.get("hide_report", setHideReport);
   } else {
     browser.storage.sync.get("api_key").then(setApiKey, onError);
     browser.storage.sync.get("stream_notifications").then(setStreamNotifications, onError);
     browser.storage.sync.get("hide_titr_spoilers").then(setHideTitrSpoilers, onError);
     browser.storage.sync.get("chat_emotes").then(setChatEmotes, onError);
     browser.storage.sync.get("infinite_infobuttons").then(setInfiniteInfobuttons, onError);
+    browser.storage.sync.get("hide_report").then(setHideReport, onError);
   }
 
   function onError(error) {


### PR DESCRIPTION
This update adds an option to hide the "Report" links in chat, as requested in Feature Request #69. This option is unchecked by default. 